### PR TITLE
Feature: Add useLocalization hook

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -3,7 +3,10 @@ This package exposes a higher order component that wraps [Next](https://nextjs.o
 
 This package is optimized to work with serverless next build (on vercel or netlify or lambda function or whatever platform). Other alternatives such as i18n would be more optimized for usage with server-based next application, but we found they do not work properly with serverless build.
 
-## How it works
+## API
+This package `withNextLocalization` (explained below) higher order component as a default export. It also exports `useLocalization` hook as a named export.
+
+### withNextLocalization
 As stated above, the localization is done through a Higher Order Component (HOC) that wraps the entire Next page and provides it with a translation function as a prop. That HOC accepts 5 parameters and they are as follows:
 1. `settings` object.
 1. `buildDictionary` Function.
@@ -42,3 +45,9 @@ const MyPage = ({ t: Translate, lang: string, /* some other props from Next */ }
 
 export withLocalization(MyPage);
 ```
+
+### useLocalization
+This is custom hook that returns an object of `{ t: (string) => string, lang: string }` which are the same props that get passed to the localized page.
+
+The hook accepts one optional argument:
+  - `customTranslation`: The same object that is passed to the localization HOC, defaults to empty array.

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@types/ramda": "^0.27.36",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
+    "@zyda/swr-internal-state": "^1.0.0",
     "ramda": "^0.27.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zyda/next-localization",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": false,
   "description": "Localization for Next.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zyda/next-localization",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "private": false,
   "description": "Localization for Next.js",
   "keywords": [

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,2 @@
+export * from './states';
+export * from './useLocalization';

--- a/src/hooks/states.ts
+++ b/src/hooks/states.ts
@@ -1,4 +1,5 @@
-import { useGlobalState } from "@zyda/swr-internal-state";
+import { useGlobalState } from '@zyda/swr-internal-state';
+import { Translate } from '../types';
 
-export const useDictionary = () => useGlobalState<Record<string, string>>('@zyda/next-localization:current-dictionary', {});
 export const useLanguage = () => useGlobalState<string>('@zyda/next-localization:current-language');
+export const useTranslate = () => useGlobalState<Translate>('@zyda/next-localization:current-t-function');

--- a/src/hooks/states.ts
+++ b/src/hooks/states.ts
@@ -1,0 +1,4 @@
+import { useGlobalState } from "@zyda/swr-internal-state";
+
+export const useDictionary = () => useGlobalState<Record<string, string>>('@zyda/next-localization:current-dictionary', {});
+export const useLanguage = () => useGlobalState<string>('@zyda/next-localization:current-language');

--- a/src/hooks/useLocalization.ts
+++ b/src/hooks/useLocalization.ts
@@ -1,0 +1,12 @@
+import { buildPageTranslateFunction } from "../helpers";
+import { CustomTranslation } from "../types";
+import { useDictionary, useLanguage } from "./states"
+
+export const useLocalization = (customTranslations: CustomTranslation[] = []) => {
+  const [dictionary] = useDictionary();
+  const [language] = useLanguage();
+
+  const t = buildPageTranslateFunction(dictionary!, language!, customTranslations);
+
+  return { t, language };
+}

--- a/src/hooks/useLocalization.ts
+++ b/src/hooks/useLocalization.ts
@@ -1,12 +1,9 @@
-import { buildPageTranslateFunction } from "../helpers";
-import { CustomTranslation } from "../types";
-import { useDictionary, useLanguage } from "./states"
+import { Translate } from '../types';
+import { useLanguage, useTranslate } from './states';
 
-export const useLocalization = (customTranslations: CustomTranslation[] = []) => {
-  const [dictionary] = useDictionary();
+export const useLocalization = (): { t: Translate, lang: string } => {
+  const [translate] = useTranslate();
   const [language] = useLanguage();
 
-  const t = buildPageTranslateFunction(dictionary!, language!, customTranslations);
-
-  return { t, lang: language };
+  return { t: translate!, lang: language! };
 }

--- a/src/hooks/useLocalization.ts
+++ b/src/hooks/useLocalization.ts
@@ -8,5 +8,5 @@ export const useLocalization = (customTranslations: CustomTranslation[] = []) =>
 
   const t = buildPageTranslateFunction(dictionary!, language!, customTranslations);
 
-  return { t, language };
+  return { t, lang: language };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,6 @@
 import withNextLocalization from './localizationHOC';
 
 export * from './types';
+export * from './hooks/useLocalization';
+
 export default withNextLocalization;

--- a/src/localizationHOC.tsx
+++ b/src/localizationHOC.tsx
@@ -5,6 +5,7 @@ import { AppContext } from 'next/app';
 
 import { WithNextLocalization, WrapperPageProps } from './types';
 import { buildPageTranslateFunction } from './helpers';
+import { useDictionary, useLanguage } from './hooks';
 
 /**
 * @param settings
@@ -29,6 +30,14 @@ const HOC: WithNextLocalization<Function & { getInitialProps?: Function }> = (
   const OldPage = page.bind({});
 
   const NewPage: typeof page = ({ dictionary, language, ...otherProps }: WrapperPageProps) => {
+    // Save the created dictionary
+    const [, setDictionaryState] = useDictionary();
+    setDictionaryState(dictionary);
+
+    // Save current language
+    const [, setLanguageState] = useLanguage();
+    setLanguageState(language);
+
     const translate = buildPageTranslateFunction(dictionary, language, customTranslations);
     return (<OldPage t={translate} lang={language} {...otherProps} />);
   };

--- a/src/localizationHOC.tsx
+++ b/src/localizationHOC.tsx
@@ -5,7 +5,7 @@ import { AppContext } from 'next/app';
 
 import { WithNextLocalization, WrapperPageProps } from './types';
 import { buildPageTranslateFunction } from './helpers';
-import { useDictionary, useLanguage } from './hooks';
+import { useLanguage, useTranslate } from './hooks';
 
 /**
 * @param settings
@@ -30,15 +30,16 @@ const HOC: WithNextLocalization<Function & { getInitialProps?: Function }> = (
   const OldPage = page.bind({});
 
   const NewPage: typeof page = ({ dictionary, language, ...otherProps }: WrapperPageProps) => {
-    // Save the created dictionary
-    const [, setDictionaryState] = useDictionary();
-    setDictionaryState(dictionary);
-
     // Save current language
     const [, setLanguageState] = useLanguage();
     setLanguageState(language);
 
     const translate = buildPageTranslateFunction(dictionary, language, customTranslations);
+
+    // Save translate function to state
+    const [, setTranslateState] = useTranslate();
+    setTranslateState(translate);
+
     return (<OldPage t={translate} lang={language} {...otherProps} />);
   };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1497,6 +1497,13 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
+"@zyda/swr-internal-state@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@zyda/swr-internal-state/-/swr-internal-state-1.0.0.tgz#d3d54728e803ee582dc9b97eecb286376d88a0a6"
+  integrity sha512-yQr4DXj2clWEblWnty03n/HKHgXyxQ/9nxCHiLcch10j2fCJyMH9SqHZc71MQej9Zv2flpzaB+ZGFV1WIRU7Gg==
+  dependencies:
+    swr "^0.4.0"
+
 abab@^2.0.3:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.5.tgz#c0b678fb32d60fc1219c784d6a826fe385aeb79a"
@@ -2745,6 +2752,11 @@ depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
+
+dequal@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.2.tgz#85ca22025e3a87e65ef75a7a437b35284a7e319d"
+  integrity sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==
 
 des.js@^1.0.0:
   version "1.0.1"
@@ -6544,6 +6556,13 @@ supports-hyperlinks@^2.0.0:
   dependencies:
     has-flag "^4.0.0"
     supports-color "^7.0.0"
+
+swr@^0.4.0:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/swr/-/swr-0.4.2.tgz#4a9ed5e9948088af145c79d716d294cb99712a29"
+  integrity sha512-SKGxcAfyijj/lE5ja5zVMDqJNudASH3WZPRUakDVOePTM18FnsXgugndjl9BSRwj+jokFCulMDe7F2pQL+VhEw==
+  dependencies:
+    dequal "2.0.2"
 
 symbol-tree@^3.2.4:
   version "3.2.4"


### PR DESCRIPTION
I added `useLocalization` hook that returns the `t` translation function and `lang` string.

As per the discussion with @Doaa-Ismael  and @AhmedMedhatHabib, I did so by saving both the built `dictionary` and `language` to a global state using `@zyda/swr-internal-state` package.

The only problem is that I could not save the custom translations, as they are a group of functions, and functions cannot be saved to states. So I made it that the custom translation array is passed to the hook, so the array is used to build the translation function.

Note that the translation function would be built properly and would work without having the custom translation, but we would face unexpected behavior if we pass some value meant for custom translation.

Also, I released version 0.2.0 by mistake when I was testing the build. I think we need to automate the release with releases to main using Github actions or so.